### PR TITLE
Add support for MediaFlow Proxy

### DIFF
--- a/src/lib/mediaflowProxy.js
+++ b/src/lib/mediaflowProxy.js
@@ -1,0 +1,112 @@
+import crypto from 'crypto';
+import { URL } from 'url';
+import path from 'path';
+import cache from './cache.js';
+
+const PRIVATE_CIDR = /^(10\.|127\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)/;
+
+function getTextHash(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+async function getMediaflowProxyPublicIp(userConfig) {
+  // If the user has already provided a public IP, use it
+  if (userConfig.mediaflowPublicIp) return userConfig.mediaflowPublicIp;
+
+  const parsedUrl = new URL(userConfig.mediaflowProxyUrl);
+  if (PRIVATE_CIDR.test(parsedUrl.hostname)) {
+    // MediaFlow proxy URL is a private IP address
+    return null;
+  }
+
+  const cacheKey = `mediaflowPublicIp:${getTextHash(`${userConfig.mediaflowProxyUrl}:${userConfig.mediaflowApiPassword}`)}`;
+  try {
+    const cachedIp = await cache.get(cacheKey);
+    if (cachedIp) {
+      return cachedIp;
+    }
+
+    const response = await fetch(new URL(`/proxy/ip?api_password=${userConfig.mediaflowApiPassword}`, userConfig.mediaflowProxyUrl).toString(), {
+      method: 'GET',
+      headers: {
+      'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const publicIp = data.ip;
+    if (publicIp) {
+      await cache.set(cacheKey, publicIp, { ttl: 300 }); // Cache for 5 minutes
+      return publicIp;
+    }
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+
+  return null;
+}
+
+
+function encodeMediaflowProxyUrl(
+  mediaflowProxyUrl,
+  endpoint,
+  destinationUrl = null,
+  queryParams = {},
+  requestHeaders = null,
+  responseHeaders = null
+) {
+  if (destinationUrl !== null) {
+    queryParams.d = destinationUrl;
+  }
+
+  // Add headers if provided
+  if (requestHeaders) {
+    Object.entries(requestHeaders).forEach(([key, value]) => {
+      queryParams[`h_${key}`] = value;
+    });
+  }
+  if (responseHeaders) {
+    Object.entries(responseHeaders).forEach(([key, value]) => {
+      queryParams[`r_${key}`] = value;
+    });
+  }
+
+  const encodedParams = new URLSearchParams(queryParams).toString();
+
+  // Construct the full URL
+  const baseUrl = new URL(endpoint, mediaflowProxyUrl).toString();
+  return `${baseUrl}?${encodedParams}`;
+}
+
+export async function updateUserConfigWithMediaFlowIp(userConfig) {
+  if (userConfig.enableMediaFlow && userConfig.mediaflowProxyUrl && userConfig.mediaflowApiPassword) {
+    const mediaflowPublicIp = await getMediaflowProxyPublicIp(userConfig);
+    if (mediaflowPublicIp) {
+      userConfig.ip = mediaflowPublicIp;
+    }
+  }
+  return userConfig;
+}
+
+
+export function applyMediaflowProxyIfNeeded(videoUrl, userConfig) {
+  if (userConfig.enableMediaFlow && userConfig.mediaflowProxyUrl && userConfig.mediaflowApiPassword) {
+    return encodeMediaflowProxyUrl(
+      userConfig.mediaflowProxyUrl,
+      "/proxy/stream",
+      videoUrl,
+      {
+        api_password: userConfig.mediaflowApiPassword
+      },
+      null,
+      {
+        "Content-Disposition": `attachment; filename=${path.basename(videoUrl)}`
+      }
+    );
+  }
+  return videoUrl;
+}

--- a/src/template/configure.html
+++ b/src/template/configure.html
@@ -6,6 +6,7 @@
     <title>Jackettio</title>
     <link rel="icon" href="/icon">
     <link href="/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <style>
       .container {
         max-width: 600px;
@@ -117,6 +118,44 @@
             <input type="{{field.type}}" v-model="field.value" class="form-control">
           </div>
         </div>
+
+        <h5>MediaFlow Proxy</h5>
+        <div class="ps-2 border-start border-secondary-subtle">
+          <div class="mb-3">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" v-model="form.enableMediaFlow" id="enableMediaFlow">
+              <label class="form-check-label" for="enableMediaFlow">Enable MediaFlow Proxy</label>
+            </div>
+          </div>
+          <div v-if="form.enableMediaFlow">
+            <div class="mb-2">
+              <a href="https://github.com/mhdzumair/mediaflow-proxy?tab=readme-ov-file#mediaflow-proxy" target="_blank" rel="noopener">
+                MediaFlow Setup Guide
+              </a>
+            </div>
+            <div class="mb-3">
+              <label for="mediaflowProxyUrl">MediaFlow Proxy URL:</label>
+              <input type="text" v-model="form.mediaflowProxyUrl" class="form-control" id="mediaflowProxyUrl" placeholder="https://your-mediaflow-proxy-url.com">
+            </div>
+            <div class="mb-3">
+              <label for="mediaflowApiPassword">MediaFlow API Password:</label>
+              <div class="input-group">
+                <input :type="showMediaFlowPassword ? 'text' : 'password'" v-model="form.mediaflowApiPassword" class="form-control" id="mediaflowApiPassword">
+                <button class="btn btn-outline-secondary" type="button" @click="toggleMediaFlowPassword">
+                  <i :class="showMediaFlowPassword ? 'bi bi-eye-slash' : 'bi bi-eye'"></i>
+                </button>
+              </div>
+            </div>
+            <div class="mb-3">
+              <label for="mediaflowPublicIp">MediaFlow Public IP (Optional):</label>
+              <small class="text-muted">
+                Configure this only when running MediaFlow locally with a proxy service. Leave empty if MediaFlow is configured locally without a proxy server or if it's hosted on a remote server.
+              </small>
+              <input type="text" v-model="form.mediaflowPublicIp" class="form-control" id="mediaflowPublicIp" placeholder="Enter public IP address">
+            </div>
+          </div>
+        </div>
+
         <div class="my-3 d-flex align-items-center">
           <button @click="configure" type="button" class="btn btn-primary" :disabled="!debrid.id">{{isUpdate ? 'Update' : 'Install'}}</button>
           <div v-if="error" class="text-danger ms-2">{{error}}</div>
@@ -140,6 +179,11 @@
           const error = ref('');
           const manifestUrl = ref('');
           let isUpdate = false;
+          const showMediaFlowPassword = ref(false);
+
+          function toggleMediaFlowPassword() {
+            showMediaFlowPassword.value = !showMediaFlowPassword.value;
+          }
 
           if(config.userConfig){
             try {
@@ -151,7 +195,7 @@
             }catch(err){}
           }
 
-          const form = {
+          const form = ref({
             maxTorrents: defaultUserConfig.maxTorrents,
             priotizePackTorrents: defaultUserConfig.priotizePackTorrents,
             excludeKeywords: defaultUserConfig.excludeKeywords.join(','),
@@ -161,18 +205,23 @@
             forceCacheNextEpisode: defaultUserConfig.forceCacheNextEpisode,
             priotizeLanguages: defaultUserConfig.priotizeLanguages,
             indexerTimeoutSec: defaultUserConfig.indexerTimeoutSec,
-            metaLanguage: defaultUserConfig.metaLanguage
-          };
+            metaLanguage: defaultUserConfig.metaLanguage,
+            enableMediaFlow: defaultUserConfig.enableMediaFlow || false,
+            mediaflowProxyUrl: defaultUserConfig.mediaflowProxyUrl || '',
+            mediaflowApiPassword: defaultUserConfig.mediaflowApiPassword || '',
+            mediaflowPublicIp: defaultUserConfig.mediaflowPublicIp || ''
+          });
+
           qualities.forEach(quality => quality.checked = defaultUserConfig.qualities.includes(quality.value));
           indexers.forEach(indexer => indexer.checked = defaultUserConfig.indexers.includes(indexer.value) || defaultUserConfig.indexers.includes('all'));
 
           async function configure(){
             try {
               error.value = '';
-              const userConfig = Object.assign({}, form);
+              const userConfig = Object.assign({}, form.value);
               userConfig.qualities = qualities.filter(quality => quality.checked).map(quality => quality.value);
               userConfig.indexers = indexers.filter(indexer => indexer.checked).map(indexer => indexer.value);
-              userConfig.excludeKeywords = form.excludeKeywords.split(',').filter(Boolean);
+              userConfig.excludeKeywords = form.value.excludeKeywords.split(',').filter(Boolean);
               debrid.value.configFields.forEach(field => {
                 if(field.required && !field.value)throw new Error(`${field.label} is required`);
                 userConfig[field.name] = field.value
@@ -193,6 +242,16 @@
               if(passkey.enabled){
                 if(userConfig.passkey && !userConfig.passkey.match(new RegExp(passkey.pattern))){
                   throw new Error(`Tracker passkey have invalid format: ${passkey.pattern}`);
+                }
+              }
+
+              // MediaFlow config validation
+              if (userConfig.enableMediaFlow) {
+                if (!userConfig.mediaflowProxyUrl) {
+                  throw new Error('MediaFlow Proxy URL is required when MediaFlow is enabled');
+                }
+                if (!userConfig.mediaflowApiPassword) {
+                  throw new Error('MediaFlow API Password is required when MediaFlow is enabled');
                 }
               }
 
@@ -218,7 +277,9 @@
             immulatableUserConfigKeys,
             languages,
             isUpdate,
-            metaLanguages
+            metaLanguages,
+            showMediaFlowPassword,
+            toggleMediaFlowPassword
           }
         }
       }).mount('#app')


### PR DESCRIPTION
This pull request adds support for the MediaFlow Proxy. It includes changes to the code that allow the user to enable the MediaFlow Proxy, configure the MediaFlow Proxy URL, API password, and public IP address (optional). 