### PR TITLE
Enable Brazilian Portuguese as priority and search languages

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -97,6 +97,7 @@ export default {
     {value: 'lithuanian', emoji: '🇱🇹', iso639: 'lt', pattern: 'lithuanian'},
     {value: 'korean',     emoji: '🇰🇷', iso639: 'ko', pattern: 'korean'},
     {value: 'portuguese', emoji: '🇵🇹', iso639: 'pt', pattern: 'portuguese'},
+    {value: 'brazilian', emoji: '🇧🇷', iso639: 'pt-br', pattern: 'portuguese'},
     {value: 'russian',    emoji: '🇷🇺', iso639: 'ru', pattern: 'rus(sian)?'},
     {value: 'swedish',    emoji: '🇸🇪', iso639: 'sv', pattern: 'swedish'},
     {value: 'tamil',      emoji: '🇮🇳', iso639: 'ta', pattern: 'tamil'},


### PR DESCRIPTION
See discussion in #34 

This patch adds support for brazilian portuguese as search language, which is important for seamless integration with my newly implemented indexers, as shown in the screenshots below:

No results for "pt" (Portugal) title
<img width="1067" alt="Screenshot 2024-11-19 at 8 00 50 PM" src="https://github.com/user-attachments/assets/c36601e7-32ff-4c29-bfea-ebeb6431ce16">

Six results for "pt-br" (Brazil) title
<img width="1069" alt="Screenshot 2024-11-19 at 8 00 59 PM" src="https://github.com/user-attachments/assets/9ae4c75e-5d60-494e-aa05-fedee90cf906">