### PR TITLE
feat: Direct P2P Torrent Mode (No Debrid Required)

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -54,7 +54,7 @@ export default {
     priotizeLanguages: commaListToArray(process.env.DEFAULT_PRIOTIZE_LANGUAGES || ''),
     priotizePackTorrents:  parseInt(process.env.DEFAULT_PRIOTIZE_PACK_TORRENTS || 2),
     forceCacheNextEpisode: (process.env.DEFAULT_FORCE_CACHE_NEXT_EPISODE || 'false') === 'true',
-    sortCached: sortCommaListToArray(process.env.DEFAULT_SORT_CACHED || 'quality:true, size:true'),
+    sortCached: sortCommaListToArray(process.env.DEFAULT_SORT_CACHED || 'quality:true, size:true, seeders:true'),
     sortUncached: sortCommaListToArray(process.env.DEFAULT_SORT_UNCACHED || 'seeders:true'),
     hideUncached:  (process.env.DEFAULT_HIDE_UNCACHED || 'false') === 'true',
     indexers: commaListToArray(process.env.DEFAULT_INDEXERS || 'all'),

--- a/src/lib/debrid.js
+++ b/src/lib/debrid.js
@@ -1,10 +1,11 @@
+import p2p from "./debrid/p2p.js";
 import debridlink from "./debrid/debridlink.js";
 import alldebrid from "./debrid/alldebrid.js";
 import realdebrid from './debrid/realdebrid.js';
 import premiumize from './debrid/premiumize.js';
 export {ERROR} from './debrid/const.js';
 
-const debrid = {debridlink, alldebrid, realdebrid, premiumize};
+const debrid = {p2p, debridlink, alldebrid, realdebrid, premiumize};
 
 export function instance(userConfig){
 

--- a/src/lib/debrid/p2p.js
+++ b/src/lib/debrid/p2p.js
@@ -1,0 +1,43 @@
+export default class P2P {
+  static id = "p2p";
+  static name = "Direct P2P Torrent (No Debrid)";
+  static shortName = "P2P";
+  static configFields = [];
+
+  constructor(userConfig) {
+    this.userConfig = userConfig;
+    this.id = P2P.id;
+    this.name = P2P.name;
+    this.shortName = P2P.shortName;
+  }
+
+  async getUserHash() {
+    return "p2p";
+  }
+
+  async getTorrentsCached(torrents, isValidCachedFiles) {
+    return torrents.map(t => { t.isCached = true; return t; });
+  }
+
+  async getProgressTorrents(torrents) {
+    return {};
+  }
+
+  async getFilesFromMagnet(magnetUrl, infoHash) {
+    return [{ name: infoHash, size: 0, infoHash, url: magnetUrl, link: magnetUrl }];
+  }
+
+  async getFilesFromBuffer(buffer, infoHash) {
+    const magnet = "magnet:?xt=urn:btih:" + infoHash;
+    return [{ name: infoHash, size: 0, infoHash, url: magnet, link: magnet }];
+  }
+
+  async getFilesFromHash(infoHash) {
+    const magnet = "magnet:?xt=urn:btih:" + infoHash;
+    return [{ name: infoHash, size: 0, infoHash, url: magnet, link: magnet }];
+  }
+
+  async getDownload(file) {
+    return file.url || file.link || ("magnet:?xt=urn:btih:" + file.infoHash);
+  }
+}

--- a/src/lib/jackettio.js
+++ b/src/lib/jackettio.js
@@ -379,6 +379,20 @@ export async function getStreams(userConfig, type, stremioId, publicUrl){
     if(torrent.progress && !torrent.isCached){
       rows.push(`⬇️ ${torrent.progress.percent}% ${bytesToSize(torrent.progress.speed)}/s`);
     }
+    if (userConfig.debridId === 'p2p') {
+      const fileIdx = file.index !== undefined ? file.index : 0;
+      return {
+        name: '[P2P] ' + config.addonName + ' ' + quality,
+        title: rows.join('\n'),
+        infoHash: torrent.infos.infoHash,
+        fileIdx: fileIdx,
+        behaviorHints: {
+          bingeGroup: 'ampere-p2p-' + quality,
+          filename: file.name || torrent.name
+        }
+      };
+    }
+
     return {
       name: `[${debridInstance.shortName}${torrent.isCached ? '+' : ''}] ${userConfig.enableMediaFlow ? '🕵🏼‍♂️ ' : ''}${config.addonName} ${quality}`,
       title: rows.join("\n"),

--- a/src/template/configure.html
+++ b/src/template/configure.html
@@ -177,7 +177,7 @@
         </div>
 
         <div class="my-3 d-flex align-items-center">
-          <button @click="configure" type="button" class="btn btn-primary" :disabled="!debrid.id">{{isUpdate ? 'Update' : 'Install'}}</button>
+          <button @click="configure" type="button" class="btn btn-primary" >{{isUpdate ? 'Update' : 'Install'}}</button>
           <div v-if="error" class="text-danger ms-2">{{error}}</div>
           <div class="ms-auto">
             <a v-if="manifestUrl" :href="manifestUrl">Stremio Link</a>


### PR DESCRIPTION
### Summary
Adds a **Direct P2P Torrent** provider option alongside RealDebrid, AllDebrid, Debrid-Link, and Premiumize.

### Use Case
For users running Jackettio who stream torrent magnets directly or run without external Debrid service subscriptions.

### Key Changes
1. `src/lib/debrid/p2p.js`: Implements the Debrid provider interface for Direct P2P Torrents.
2. `src/lib/debrid.js`: Registers `p2p` in the provider map.
3. `src/lib/config.js`: Includes `seeders:true` in default `sortCached` configuration (`quality:true, size:true, seeders:true`).
4. `src/template/configure.html`: Enables installation/updates in P2P mode without requiring an API key.
5. `src/lib/jackettio.js`: Formats P2P stream responses as native Stremio `{ infoHash, fileIdx, behaviorHints }` objects.
